### PR TITLE
Initial Term and Taxonomy support

### DIFF
--- a/src/Contracts/BuildsQueries.php
+++ b/src/Contracts/BuildsQueries.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Silk\Contracts;
+
+use Illuminate\Support\Collection;
+
+interface BuildsQueries
+{
+    /**
+     * Set the model for this query.
+     *
+     * @param mixed $model
+     *
+     * @return $this
+     */
+    public function setModel($model);
+
+    /**
+     * Get the model.
+     *
+     * @return mixed Model
+     */
+    public function getModel();
+
+    /**
+     * Get the results of the query.
+     *
+     * @return Collection
+     */
+    public function results();
+}

--- a/src/Post/PostType.php
+++ b/src/Post/PostType.php
@@ -179,4 +179,16 @@ class PostType
 
         return null;
     }
+
+    /**
+     * Magic Isset Check.
+     *
+     * @param  string  $property Queried property name
+     *
+     * @return boolean
+     */
+    public function __isset($property)
+    {
+        return ! is_null($this->__get($property));
+    }
 }

--- a/src/Post/PostType.php
+++ b/src/Post/PostType.php
@@ -11,6 +11,7 @@ use Silk\Post\Exception\NonExistentPostTypeException;
 use Silk\Post\PostTypeBuilder;
 
 /**
+ * @property-read string $id
  * @property-read string $slug
  * @property-read string $one
  * @property-read string $many
@@ -160,15 +161,16 @@ class PostType
     }
 
     /**
-     * Magic Getter
+     * Magic Getter.
      *
-     * @param  string $property
+     * @param  string $property  Accessed property name
      *
      * @return mixed
      */
     public function __get($property)
     {
         switch ($property) :
+            case 'id':
             case 'slug':
                 return $this->object->name;
             case 'one':

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -22,19 +22,4 @@ trait QueryBuilder
     {
         return (new static)->newQuery();
     }
-
-    /**
-     * Handle dynamic method calls into the model.
-     *
-     * @param  string $method
-     * @param  array $arguments
-     *
-     * @return mixed
-     */
-    public function __call($method, $arguments)
-    {
-        $query = $this->newQuery();
-
-        return call_user_func_array([$query, $method], $arguments);
-    }
 }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Silk\Query;
+
+use Silk\Contracts\BuildsQueries;
+
+trait QueryBuilder
+{
+    /**
+     * Get a new query builder for the model.
+     *
+     * @return BuildsQueries
+     */
+    abstract public function newQuery();
+
+    /**
+     * Create a new query builder instance for this model type.
+     *
+     * @return BuildsQueries
+     */
+    public static function query()
+    {
+        return (new static)->newQuery();
+    }
+
+    /**
+     * Handle dynamic method calls into the model.
+     *
+     * @param  string $method
+     * @param  array $arguments
+     *
+     * @return mixed
+     */
+    public function __call($method, $arguments)
+    {
+        $query = $this->newQuery();
+
+        return call_user_func_array([$query, $method], $arguments);
+    }
+}

--- a/src/Taxonomy/Exception/NonExistentTaxonomyException.php
+++ b/src/Taxonomy/Exception/NonExistentTaxonomyException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Silk\Taxonomy\Exception;
+
+class NonExistentTaxonomyException extends \Exception
+{
+}

--- a/src/Taxonomy/Taxonomy.php
+++ b/src/Taxonomy/Taxonomy.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Silk\Taxonomy;
+
+use Silk\Term\TermQueryBuilder;
+use Illuminate\Support\Collection;
+use Silk\Exception\WP_ErrorException;
+
+/**
+ * @property-read string   $id
+ * @property-read stdClass $taxonomy
+ *
+ * @property-read bool     $_builtin
+ * @property-read stdClass $cap
+ * @property-read string   $description
+ * @property-read bool     $hierarchical
+ * @property-read string   $label
+ * @property-read stdClass $labels
+ * @property-read callable $meta_box_cb
+ * @property-read string   $name
+ * @property-read array    $object_type
+ * @property-read bool     $public
+ * @property-read bool     $publicly_queryable
+ * @property-read string   $query_var
+ * @property-read array    $rewrite
+ * @property-read bool     $show_admin_column
+ * @property-read bool     $show_in_menu
+ * @property-read bool     $show_in_nav_menus
+ * @property-read bool     $show_in_quick_edit
+ * @property-read bool     $show_tagcloud
+ * @property-read bool     $show_ui
+ * @property-read callable $update_count_callback
+ */
+class Taxonomy
+{
+    /**
+     * The Taxonomy identifier
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * The taxonomy object
+     * @var object
+     */
+    protected $taxonomy;
+
+    /**
+     * Taxonomy Constructor.
+     *
+     * @param object $taxonomy  The taxonomy object
+     */
+    public function __construct($taxonomy)
+    {
+        if (empty($taxonomy->name) || ! static::exists($taxonomy->name)) {
+            throw new Exception\NonExistentTaxonomyException;
+        }
+
+        $this->id = $taxonomy->name;
+        $this->taxonomy = $taxonomy;
+    }
+
+    /**
+     * Create a new instance using the taxonomy identifier.
+     *
+     * @param  string $identifier Taxonomy name/identifier
+     *
+     * @return static
+     */
+    public static function make($identifier)
+    {
+        return new static(get_taxonomy($identifier));
+    }
+
+    /**
+     * Check if the given taxonomy exists.
+     *
+     * @param  string $identifier The taxonomy identifier
+     *
+     * @return bool
+     */
+    public static function exists($identifier)
+    {
+        return taxonomy_exists($identifier);
+    }
+
+    /**
+     * Start a new query for terms of this taxonomy.
+     *
+     * @return TermQueryBuilder
+     */
+    public function terms()
+    {
+        return (new TermQueryBuilder)->forTaxonomy($this);
+    }
+
+    /**
+     * Unregister the taxonomy.
+     *
+     * @return $this
+     */
+    public function unregister()
+    {
+        if (! static::exists($this->taxonomy->name)) {
+            throw new Exception\NonExistentTaxonomyException;
+        }
+
+        if (is_wp_error($error = unregister_taxonomy($this->taxonomy->name))) {
+            throw new WP_ErrorException($error);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Magic Getter.
+     *
+     * @param  string $property Accessed property
+     *
+     * @return mixed
+     */
+    public function __get($property)
+    {
+        if (isset($this->$property)) {
+            return $this->$property;
+        }
+
+        if (isset($this->taxonomy->$property)) {
+            return $this->taxonomy->$property;
+        }
+    }
+}

--- a/src/Taxonomy/Taxonomy.php
+++ b/src/Taxonomy/Taxonomy.php
@@ -2,6 +2,7 @@
 
 namespace Silk\Taxonomy;
 
+use Silk\Post\PostType;
 use Silk\Term\TermQueryBuilder;
 use Illuminate\Support\Collection;
 use Silk\Exception\WP_ErrorException;
@@ -92,6 +93,19 @@ class Taxonomy
     public function terms()
     {
         return (new TermQueryBuilder)->forTaxonomy($this);
+    }
+
+    /**
+     * Get all post types associated with this taxonomy.
+     *
+     * @return Collection
+     */
+    public function postTypes()
+    {
+        return Collection::make($this->object_type)
+            ->map(function ($post_type) {
+                return PostType::load($post_type);
+            });
     }
 
     /**

--- a/src/Term/Category.php
+++ b/src/Term/Category.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Silk\Term;
+
+class Category extends Model
+{
+    const TAXONOMY = 'category';
+}

--- a/src/Term/Exception/TaxonomyMismatchException.php
+++ b/src/Term/Exception/TaxonomyMismatchException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Silk\Term\Exception;
+
+class TaxonomyMismatchException extends \RuntimeException
+{
+    
+}

--- a/src/Term/Exception/TermNotFoundException.php
+++ b/src/Term/Exception/TermNotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Silk\Term\Exception;
+
+class TermNotFoundException extends \RuntimeException
+{
+    
+}

--- a/src/Term/Model.php
+++ b/src/Term/Model.php
@@ -152,6 +152,21 @@ abstract class Model
     }
 
     /**
+     * Delete the term from the database.
+     *
+     * @return $this
+     */
+    public function delete()
+    {
+        if ($result = wp_delete_term($this->id, static::TAXONOMY)) {
+            $this->term->term_id = null;
+            $this->term->term_taxonomy_id = 0;
+        }
+
+        return $this;
+    }
+
+    /**
      * Check if this term exists in the database.
      *
      * @return boolean
@@ -183,6 +198,29 @@ abstract class Model
     }
 
     /**
+     * Get the parent term instance.
+     *
+     * @return static
+     */
+    public function parent()
+    {
+        return static::fromID($this->term->parent);
+    }
+
+    /**
+     * Get all ancestors of this term as a collection.
+     *
+     * @return Collection
+     */
+    public function ancestors()
+    {
+        return Collection::make(get_ancestors($this->id, static::TAXONOMY, 'taxonomy'))
+            ->map(function ($term_ID) {
+                return static::fromID($term_ID);
+            });
+    }
+
+    /**
      * Magic Getter.
      *
      * @param  string $property Property name accessed
@@ -200,6 +238,18 @@ abstract class Model
         }
 
         return null;
+    }
+
+    /**
+     * Magic set checker.
+     *
+     * @param  string  $property  Property name queried
+     *
+     * @return boolean
+     */
+    public function __isset($property)
+    {
+        return property_exists($this->term, $property);
     }
 
     /**

--- a/src/Term/Model.php
+++ b/src/Term/Model.php
@@ -4,6 +4,7 @@ namespace Silk\Term;
 
 use stdClass;
 use WP_Term;
+use Silk\Taxonomy\Taxonomy;
 use Silk\Query\QueryBuilder;
 use Illuminate\Support\Collection;
 use Silk\Exception\WP_ErrorException;
@@ -221,6 +222,16 @@ abstract class Model
             ->map(function ($term_ID) {
                 return static::fromID($term_ID);
             });
+    }
+
+    /**
+     * Get the Taxonomy model.
+     *
+     * @return Taxonomy
+     */
+    public function taxonomy()
+    {
+        return Taxonomy::make($this->taxonomy);
     }
 
     /**

--- a/src/Term/Model.php
+++ b/src/Term/Model.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Silk\Term;
+
+use stdClass;
+use WP_Term;
+use Silk\Exception\WP_ErrorException;
+use Silk\Term\Exception\TermNotFoundException;
+use Silk\Term\Exception\TaxonomyMismatchException;
+
+/**
+ * @property-read int $id
+ * @property int $term_id
+ * @property string $name
+ * @property string $slug
+ * @property string $term_group
+ * @property int $term_taxonomy_id
+ * @property string $taxonomy
+ * @property string $description
+ * @property int $parent
+ * @property int $count
+ */
+abstract class Model
+{
+    /**
+     * The term's taxonomy
+     * @var string
+     */
+    const TAXONOMY = '';
+
+    /**
+     * The term object
+     * @var WP_Term
+     */
+    protected $term;
+
+    /**
+     * Model Constructor.
+     *
+     * @param mixed $term  WP_Term to fill data from
+     */
+    public function __construct(WP_Term $term = null)
+    {
+        if (! $term) {
+            $term = new WP_Term(new stdClass);
+            $term->taxonomy = static::TAXONOMY;
+        }
+
+        if ($term->taxonomy !== static::TAXONOMY) {
+            throw new TaxonomyMismatchException();
+        }
+
+        $this->term = $term;
+    }
+
+    /**
+     * Create a new instance from a WP_Term object.
+     *
+     * @param  WP_Term $term [description]
+     *
+     * @return static
+     */
+    public static function fromWpTerm(WP_Term $term)
+    {
+        return new static($term);
+    }
+
+    /**
+     * Create a new instance from a term ID.
+     *
+     * @param  int|string $id  Term ID
+     *
+     * @return static
+     */
+    public static function fromID($id)
+    {
+        if (! $term = get_term_by('id', (int) $id, static::TAXONOMY)) {
+            throw new TermNotFoundException("No term found with ID $id.");
+        }
+
+        return static::fromWpTerm($term);
+    }
+
+    /**
+     * Create a new instance from a slug.
+     *
+     * @param  string $slug  Term slug
+     *
+     * @return static
+     */
+    public static function fromSlug($slug)
+    {
+        if (! $term = get_term_by('slug', $slug, static::TAXONOMY)) {
+            throw new TermNotFoundException("No term found with slug '$slug'.");
+        }
+
+        return static::fromWpTerm($term);
+    }
+
+    /**
+     * Save or update the term instance in the database.
+     *
+     * @return $this
+     */
+    public function save()
+    {
+        $ids = wp_insert_term($this->name, static::TAXONOMY);
+
+        if (is_wp_error($ids)) {
+            throw new WP_ErrorException($ids);
+        }
+
+        foreach ($ids as $field => $id) {
+            $this->term->$field = $id;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Magic Getter.
+     *
+     * @param  string $property Property name accessed
+     *
+     * @return mixed
+     */
+    public function __get($property)
+    {
+        if ('id' == strtolower($property)) {
+            return $this->term->term_id;
+        }
+
+        if (isset($this->term->$property)) {
+            return $this->term->$property;
+        }
+
+        return null;
+    }
+
+    /**
+     * Magic Setter.
+     *
+     * @param string $property  Property name assigned
+     * @param mixed  $value     Assigned property value
+     */
+    public function __set($property, $value)
+    {
+        $this->term->$property = $value;
+    }
+}

--- a/src/Term/Model.php
+++ b/src/Term/Model.php
@@ -4,6 +4,7 @@ namespace Silk\Term;
 
 use stdClass;
 use WP_Term;
+use Silk\Query\QueryBuilder;
 use Illuminate\Support\Collection;
 use Silk\Exception\WP_ErrorException;
 use Silk\Term\Exception\TermNotFoundException;
@@ -23,6 +24,8 @@ use Silk\Term\Exception\TaxonomyMismatchException;
  */
 abstract class Model
 {
+    use QueryBuilder;
+
     /**
      * The term's taxonomy
      * @var string
@@ -218,6 +221,16 @@ abstract class Model
             ->map(function ($term_ID) {
                 return static::fromID($term_ID);
             });
+    }
+
+    /**
+     * Start a new query for terms of this type.
+     *
+     * @return TermQueryBuilder
+     */
+    public function newQuery()
+    {
+        return (new TermQueryBuilder)->setModel($this);
     }
 
     /**

--- a/src/Term/Model.php
+++ b/src/Term/Model.php
@@ -4,6 +4,7 @@ namespace Silk\Term;
 
 use stdClass;
 use WP_Term;
+use Silk\Meta\ObjectMeta;
 use Silk\Taxonomy\Taxonomy;
 use Silk\Query\QueryBuilder;
 use Illuminate\Support\Collection;
@@ -222,6 +223,24 @@ abstract class Model
             ->map(function ($term_ID) {
                 return static::fromID($term_ID);
             });
+    }
+
+    /**
+     * Meta API for this term
+     *
+     * @param  string $key  Meta key to retreive or empty to retreive all.
+     *
+     * @return object
+     */
+    public function meta($key = '')
+    {
+        $meta = new ObjectMeta('term', $this->id);
+
+        if ($key) {
+            return $meta->get($key);
+        }
+
+        return $meta;
     }
 
     /**

--- a/src/Term/Tag.php
+++ b/src/Term/Tag.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Silk\Term;
+
+class Tag extends Model
+{
+    const TAXONOMY = 'post_tag';
+}

--- a/src/Term/TermQueryBuilder.php
+++ b/src/Term/TermQueryBuilder.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Silk\Term;
+
+use WP_Term;
+use Silk\Term\Model;
+use Silk\Contracts\BuildsQueries;
+use Silk\Exception\WP_ErrorException;
+use Illuminate\Support\Collection;
+
+class TermQueryBuilder implements BuildsQueries
+{
+    /**
+     * The term model
+     * @var Model
+     */
+    protected $model;
+
+    /**
+     * Collection of arguments
+     * @var Collection
+     */
+    protected $args;
+
+    /**
+     * Taxonomy Identifier
+     * @var string
+     */
+    protected $taxonomy;
+
+    /**
+     * TermQueryBuilder Constructor.
+     *
+     * @param array $args
+     */
+    public function __construct(array $args = [])
+    {
+        $this->args = Collection::make($args);
+    }
+
+    /**
+     * Restrict the query to terms of the provided Taxonomy.
+     *
+     * @param  string $taxonomy
+     *
+     * @return $this
+     */
+    public function forTaxonomy($taxonomy)
+    {
+        $this->taxonomy = $taxonomy;
+
+        return $this;
+    }
+
+    public function includeEmpty()
+    {
+        $this->args->put('hide_empty', false);
+
+        return $this;
+    }
+
+    /**
+     * Limit the maximum number of results returned.
+     *
+     * @param  int $max_results  Maximum number to return. 0 or 'all' for unlimited.
+     *
+     * @return $this
+     */
+    public function limit($max_results)
+    {
+        $this->args->put('number', intval($max_results));
+
+        return $this;
+    }
+
+    /**
+     * Get the query results.
+     *
+     * @throws WP_ErrorException
+     *
+     * @return Collection
+     */
+    public function results()
+    {
+        if ($this->model) {
+            return $this->collectModels();
+        }
+
+        if ($this->taxonomy) {
+            $this->args->put('taxonomy', $this->taxonomy);
+        }
+
+        return Collection::make($this->fetchTerms());
+    }
+
+    /**
+     * Get the results as a collection of models.
+     *
+     * @return Collection
+     */
+    protected function collectModels()
+    {
+        $this->args->put('taxonomy', $this->model->taxonomy);
+        $this->args->put('fields', 'all');
+
+        $modelClass = get_class($this->model);
+
+        return Collection::make($this->fetchTerms())
+            ->map(function (WP_Term $term) use ($modelClass) {
+                return new $modelClass($term);
+            });
+    }
+
+    /**
+     * Set the model for this query.
+     *
+     * @param mixed $model
+     *
+     * @return $this
+     */
+    public function setModel($model)
+    {
+        $this->model = $model;
+
+        return $this;
+    }
+
+    /**
+     * Get the model.
+     *
+     * @return mixed Model
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+
+    /**
+     * Perform the term query and return the results.
+     *
+     * @throws WP_ErrorException
+     *
+     * @return array
+     */
+    protected function fetchTerms()
+    {
+        if (is_wp_error($terms = get_terms($this->args->toArray()))) {
+            throw new WP_ErrorException($terms);
+        }
+
+        return $terms;
+    }
+}

--- a/tests/unit/Taxonomy/TaxonomyTest.php
+++ b/tests/unit/Taxonomy/TaxonomyTest.php
@@ -131,5 +131,12 @@ class TaxonomyTest extends WP_UnitTestCase
         $this->assertContains('cat', $types->pluck('id'));
     }
 
+    /**
+     * @test
+     */
+    public function non_existent_properties_return_null()
+    {
+        $this->assertNull(Taxonomy::make('category')->non_existent);
+    }
 
 }

--- a/tests/unit/Taxonomy/TaxonomyTest.php
+++ b/tests/unit/Taxonomy/TaxonomyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Silk\Term\Category;
+use Silk\Taxonomy\Taxonomy;
+use Silk\Contracts\BuildsQueries;
+use Illuminate\Support\Collection;
+
+
+class TaxonomyTest extends WP_UnitTestCase
+{
+    /**
+     * @test
+     */
+    function it_can_staticly_check_the_existence_of_a_given_taxonomy()
+    {
+        $this->assertTrue(Taxonomy::exists('category'));
+        $this->assertTrue(Taxonomy::exists('post_tag'));
+        $this->assertFalse(Taxonomy::exists('non-existent'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_takes_the_taxonomy_object_to_construct()
+    {
+        $object = get_taxonomy('category');
+        $taxonomy = new Taxonomy($object);
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_named_constructor_which_takes_the_taxonomy_identifier()
+    {
+        $this->assertInstanceOf(Taxonomy::class, Taxonomy::make('category'));
+    }
+
+    /**
+     * @test
+     * @expectedException Silk\Taxonomy\Exception\NonExistentTaxonomyException
+     */
+    public function it_blows_up_if_constructed_with_a_nonexistent_taxonomy()
+    {
+        new Taxonomy(get_taxonomy('non-existent'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_unregister_the_taxonomy()
+    {
+        $this->assertFalse(Taxonomy::exists('temp'));
+
+        register_taxonomy('temp', []);
+
+        $this->assertTrue(Taxonomy::exists('temp'));
+
+        $taxonomy = new Taxonomy(get_taxonomy('temp'));
+        $taxonomy->unregister();
+
+        $this->assertFalse(Taxonomy::exists('temp'));
+    }
+
+    /**
+     * @test
+     * @expectedException Silk\Taxonomy\Exception\NonExistentTaxonomyException
+     */
+    public function it_blows_up_if_trying_to_unregister_a_nonexistent_taxonomy()
+    {
+        register_taxonomy('temp', []);
+
+        $taxonomy = new Taxonomy(get_taxonomy('temp'));
+
+        unregister_taxonomy('temp');
+
+        $taxonomy->unregister();
+    }
+
+    /**
+     * @test
+     * @expectedException Silk\Exception\WP_ErrorException
+     */
+    public function it_blows_up_if_attempting_to_unregister_a_builtin_taxonomy()
+    {
+        $taxonomy = new Taxonomy(get_taxonomy('category'));
+        $taxonomy->unregister();
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_method_for_fetching_terms()
+    {
+        $this->assertInstanceOf(BuildsQueries::class, Taxonomy::make('category')->terms());
+    }
+
+    /**
+     * @test
+     */
+    public function it_proxies_properties_to_the_taxonomy_object()
+    {
+        $model = Taxonomy::make('category');
+
+        $this->assertSame('Categories', $model->label);
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_readonly_properties()
+    {
+        $model = Taxonomy::make('category');
+
+        $this->assertSame('category', $model->id);
+    }
+
+}

--- a/tests/unit/Taxonomy/TaxonomyTest.php
+++ b/tests/unit/Taxonomy/TaxonomyTest.php
@@ -114,4 +114,22 @@ class TaxonomyTest extends WP_UnitTestCase
         $this->assertSame('category', $model->id);
     }
 
+    /**
+     * @test
+     */
+    public function it_can_return_a_collection_of_post_types_associated_with_it()
+    {
+        register_taxonomy('breed', ['dog', 'cat']);
+        register_post_type('dog', ['taxonomies' => (array) 'breed']);
+        register_post_type('cat', ['taxonomies' => (array) 'breed']);
+
+        $types = Taxonomy::make('breed')->postTypes();
+
+        $this->assertInstanceOf(Collection::class, $types);
+        $this->assertCount(2, $types);
+        $this->assertContains('dog', $types->pluck('id'));
+        $this->assertContains('cat', $types->pluck('id'));
+    }
+
+
 }

--- a/tests/unit/Term/TermFactoryHelpers.php
+++ b/tests/unit/Term/TermFactoryHelpers.php
@@ -1,0 +1,26 @@
+<?php
+
+trait TermFactoryHelpers
+{
+    protected function createManyTagsForPost($count, $post_id)
+    {
+        $tags = $this->createManyTags($count);
+        $this->factory->term->add_post_terms($post_id, $tags, 'post_tag');
+    }
+
+    protected function createManyCatsForPost($count, $post_id)
+    {
+        $tags = $this->createManyCats($count);
+        $this->factory->term->add_post_terms($post_id, $tags, 'category');
+    }
+
+    protected function createManyTags($count)
+    {
+        return $this->factory->term->create_many($count, ['taxonomy' => 'post_tag']);
+    }
+
+    protected function createManyCats($count)
+    {
+        return $this->factory->term->create_many($count, ['taxonomy' => 'category']);
+    }
+}

--- a/tests/unit/Term/TermQueryBuilderTest.php
+++ b/tests/unit/Term/TermQueryBuilderTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use Silk\Term\Category;
+use Silk\Taxonomy\Taxonomy;
+use Silk\Term\TermQueryBuilder;
+use Illuminate\Support\Collection;
+
+class TermQueryBuilderTest extends WP_UnitTestCase
+{
+    use TermFactoryHelpers;
+
+    /**
+     * @test
+     */
+    public function it_returns_the_results_as_a_collection()
+    {
+        $query = new TermQueryBuilder;
+
+        $this->assertInstanceOf(Collection::class, $query->results());
+    }
+
+    /**
+     * @test
+     */
+    function it_can_limit_the_results_to_a_given_taxonomy()
+    {
+        /**
+         * By default get_terms does not include any that are not assigned to a post.
+         *
+         * We will limit the query to tags, but to be sure, assign all terms to a post.
+         */
+        $post_id = $this->factory->post->create();
+        $this->createManyTagsForPost(3, $post_id);
+        $this->createManyCatsForPost(3, $post_id);
+
+        $results = (new TermQueryBuilder)
+            ->forTaxonomy('post_tag')
+            ->results();
+
+        $this->assertCount(3, $results);
+        $this->assertSame(['post_tag','post_tag','post_tag'], $results->pluck('taxonomy')->all());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_include_unattached_terms()
+    {
+        $post_id = $this->factory->post->create();
+        $this->createManyTags(3); // empties
+        $this->createManyTagsForPost(3, $post_id); // assigned
+
+        $query = (new TermQueryBuilder)
+            ->forTaxonomy('post_tag')
+            ->includeEmpty();
+
+        $results = $query->results();
+
+        $this->assertCount(6, $results);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_limit_the_maximum_number_of_results_to_a_given_number()
+    {
+        $this->createManyTags(7);
+
+        $query = (new TermQueryBuilder)
+            ->includeEmpty()
+            ->limit(5);
+
+        $this->assertCount(5, $query->results());
+    }
+
+    /**
+     * @test
+     * @expectedException Silk\Exception\WP_ErrorException
+     */
+    public function it_blows_up_if_trying_to_query_terms_of_a_non_taxonomy()
+    {
+        (new TermQueryBuilder)
+            ->forTaxonomy('non-existent')
+            ->results();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_accept_and_return_a_model()
+    {
+        $model = new Category;
+        $builder = (new TermQueryBuilder)->setModel($model);
+
+        $this->assertSame($model, $builder->getModel());
+    }
+
+}

--- a/tests/unit/Term/TermTest.php
+++ b/tests/unit/Term/TermTest.php
@@ -3,6 +3,8 @@
 use Silk\Term\Tag;
 use Silk\Term\Category;
 use Silk\Taxonomy\Taxonomy;
+use Silk\Meta\Meta;
+use Silk\Meta\ObjectMeta;
 
 class TermTest extends WP_UnitTestCase
 {
@@ -283,4 +285,18 @@ class TermTest extends WP_UnitTestCase
         $this->assertSame('category', $term->taxonomy()->id);
     }
 
+    /**
+     * @test
+     */
+    public function it_has_a_method_for_accessing_the_meta_api()
+    {
+        $model = Category::create(['name' => 'Testing']);
+
+        $this->assertInstanceOf(ObjectMeta::class, $model->meta());
+        $this->assertInstanceOf(Meta::class, $model->meta('some-key'));
+
+        $model->meta('some-key')->set('single value');
+
+        $this->assertSame('single value', get_term_meta($model->id, 'some-key', true));
+    }
 }

--- a/tests/unit/Term/TermTest.php
+++ b/tests/unit/Term/TermTest.php
@@ -170,10 +170,84 @@ class TermTest extends WP_UnitTestCase
     /**
      * @test
      */
+    function it_can_delete_itself()
+    {
+        $model = Category::create(['name' => 'Doomed']);
+        $this->assertTrue($model->exists());
+
+        $model->delete();
+
+        $this->assertFalse($model->exists());
+        $this->assertEmpty($model->id);
+        $this->assertEmpty($model->term_taxonomy_id);
+    }
+
+    /**
+     * @test
+     */
+    function it_blows_up_if_it_tries_to_delete_a_non_existent_term()
+    {
+        $model = new Category; // does not exist yet
+        $model->delete();
+    }
+
+    /**
+     * @test
+     */
     function that_non_existent_properties_return_null()
     {
         $model = new Category;
         $this->assertNull($model->non_existent_property);
+    }
+
+    /**
+     * @test
+     */
+    function it_reports_proxied_properties_as_set()
+    {
+        $model = new Category;
+        $this->assertTrue(isset($model->term_id));
+    }
+
+    /**
+     * @test
+     */
+    function it_has_a_method_for_returning_the_parent_instance()
+    {
+        $parent = Category::create([
+            'name' => 'Parent'
+        ]);
+
+        $child = Category::create([
+            'name' => 'Child',
+            'parent' => $parent->id
+        ]);
+
+        $this->assertSame($child->parent, $child->parent()->id);
+    }
+
+    /**
+     * @test
+     */
+    function it_has_a_method_for_getting_a_collection_of_all_term_ancestors()
+    {
+        $grand = Category::create([
+            'name' => 'Grandparent'
+        ]);
+        $parent = Category::create([
+            'name' => 'Parent',
+            'parent' => $grand->id
+        ]);
+        $child = Category::create([
+            'name' => 'Child',
+            'parent' => $parent->id
+        ]);
+
+        $ancestor_ids = $child->ancestors()->pluck('term_id');
+
+        $this->assertCount(2, $ancestor_ids);
+        $this->assertContains($grand->id, $ancestor_ids);
+        $this->assertContains($parent->id, $ancestor_ids);
     }
 
 }

--- a/tests/unit/Term/TermTest.php
+++ b/tests/unit/Term/TermTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use Silk\Term\Tag;
 use Silk\Term\Category;
 
 class TermTest extends WP_UnitTestCase
 {
+    use TermFactoryHelpers;
+
     /**
      * @test
      */
@@ -248,6 +251,24 @@ class TermTest extends WP_UnitTestCase
         $this->assertCount(2, $ancestor_ids);
         $this->assertContains($grand->id, $ancestor_ids);
         $this->assertContains($parent->id, $ancestor_ids);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_query_terms_of_the_same_type()
+    {
+        $post_id = $this->factory->post->create();
+
+        $this->createManyTagsForPost(5, $post_id);
+
+        $tags = Tag::query()->results();
+
+        $this->assertCount(5, $tags);
+
+        foreach ($tags as $tag) {
+            $this->assertInstanceOf(Tag::class, $tag);
+        }
     }
 
 }

--- a/tests/unit/Term/TermTest.php
+++ b/tests/unit/Term/TermTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Silk\Term\Category;
+
+class TermTest extends WP_UnitTestCase
+{
+    /**
+     * @test
+     */
+    function it_can_create_a_term_from_a_new_instance()
+    {
+        $model = new Category();
+        $model->name = 'Red';
+        $model->save();
+
+        $term = get_term_by('name', 'Red', 'category');
+
+        $this->assertSame($model->id, $term->term_id);
+    }
+
+    /**
+     * @test
+     */
+    function it_can_create_a_new_instance_from_a_wp_term()
+    {
+        wp_insert_term('Blue', 'category');
+        $term = get_term_by('name', 'Blue', 'category');
+
+        $model = Category::fromWpTerm($term);
+
+        $this->assertInstanceOf(Category::class, $model);
+        $this->assertSame($term->term_id, $model->id);
+    }
+
+    /**
+     * @test
+     */
+    function it_can_create_a_new_instance_from_a_term_slug()
+    {
+        wp_insert_term('Green', 'category');
+
+        $model = Category::fromSlug('green');
+
+        $term = get_term_by('slug', 'green', 'category');
+
+        $this->assertSame($term->term_id, $model->id);
+    }
+
+    /**
+     * @test
+     * @expectedException Silk\Term\Exception\TermNotFoundException
+     */
+    function it_blows_up_if_the_term_cannot_be_found_by_slug()
+    {
+        Category::fromSlug('non-existent-slug');
+    }
+
+    /**
+     * @test
+     * @expectedException Silk\Term\Exception\TaxonomyMismatchException
+     */
+    function it_blows_up_if_the_terms_taxonomy_does_not_match_the_models()
+    {
+            wp_insert_term('Green', 'post_tag');
+            $term = get_term_by('name', 'Green', 'post_tag');
+
+            Category::fromWpTerm($term);
+    }
+
+    /**
+     * @test
+     */
+    function it_can_create_a_new_instance_from_a_term_id()
+    {
+        $ids = wp_insert_term('Purple', 'category');
+
+        $model = Category::fromID($ids['term_id']);
+
+        $this->assertInstanceOf(Category::class, $model);
+        $this->assertSame($ids['term_id'], $model->id);
+    }
+
+}

--- a/tests/unit/Term/TermTest.php
+++ b/tests/unit/Term/TermTest.php
@@ -2,6 +2,7 @@
 
 use Silk\Term\Tag;
 use Silk\Term\Category;
+use Silk\Taxonomy\Taxonomy;
 
 class TermTest extends WP_UnitTestCase
 {
@@ -269,6 +270,17 @@ class TermTest extends WP_UnitTestCase
         foreach ($tags as $tag) {
             $this->assertInstanceOf(Tag::class, $tag);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_method_for_returning_the_taxonomy_model()
+    {
+        $term = new Category;
+
+        $this->assertInstanceOf(Taxonomy::class, $term->taxonomy());
+        $this->assertSame('category', $term->taxonomy()->id);
     }
 
 }


### PR DESCRIPTION
This adds the initial functionality for Terms and Taxonomies.

The Term model behaves very much like the Post model, and instances can be created and worked with in very much the same way.

The term class also provides a similar query builder syntax, for querying and Terms of the model's type.

Targets #4 and #5, no taxonomy builder.. yet.
