### PR TITLE
Feature / labels

### DIFF
--- a/src/Post/PostType.php
+++ b/src/Post/PostType.php
@@ -165,12 +165,16 @@ class PostType
      */
     public function __get($property)
     {
+        $default = isset($this->object->$property)
+            ? $this->object->$property
+            : null;
+
         return Collection::make([
             'id'   => $this->object->name,
             'slug' => $this->object->name,
             'one'  => $this->object->labels->singular_name,
             'many' => $this->object->labels->name,
-        ])->get($property);
+        ])->get($property, $default);
     }
 
     /**

--- a/src/Post/PostTypeBuilder.php
+++ b/src/Post/PostTypeBuilder.php
@@ -216,21 +216,12 @@ class PostTypeBuilder
     /**
      * Magic Getter
      *
-     * @param  string $property
+     * @param  string $property  The accessed property
      *
      * @return mixed
      */
     public function __get($property)
     {
-        switch ($property) :
-            case 'slug':
-                return $this->slug;
-            case 'one':
-                return $this->labelSingular;
-            case 'many':
-                return $this->labelPlural;
-        endswitch;
-
         return null;
     }
 }

--- a/src/Post/PostTypeLabels.php
+++ b/src/Post/PostTypeLabels.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Silk\Post;
+
+use Illuminate\Support\Collection;
+use Silk\Support\LabelsCollection;
+
+class PostTypeLabels
+{
+    /**
+     * Labels referencing the singular form
+     * @var array
+     */
+    protected $singular = [
+        'add_new_item'          => 'Add New %s',
+        'archives'              => '%s Archives',
+        'edit_item'             => 'Edit %s',
+        'insert_into_item'      => 'Insert into %s',
+        'name_admin_bar'        => '%s',
+        'new_item'              => 'New %s',
+        'singular_name'         => '%s',
+        'uploaded_to_this_item' => 'Uploaded to this %s',
+        'view_item'             => 'View %s',
+    ];
+
+    /**
+     * Labels referencing the plural form
+     * @var array
+     */
+    protected $plural = [
+        'all_items'             => 'All %s',
+        'filter_items_list'     => 'Filter %s list',
+        'items_list_navigation' => '%s list navigation',
+        'items_list'            => '%s list',
+        'menu_name'             => '%s',
+        'name'                  => '%s',
+        'not_found_in_trash'    => 'No %s found in Trash.',
+        'not_found'             => 'No %s found.',
+        'search_items'          => 'Search %s',
+    ];
+
+    /**
+     * The master collection of labels
+     * @var Collection
+     */
+    protected $labels;
+
+    /**
+     * Set the singular labels using the given form.
+     *
+     * @param $this
+     */
+    public function setSingular($label)
+    {
+        $this->merge(
+            LabelsCollection::make($this->singular)->setForm($label)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Set the plural labels using the given form.
+     *
+     * @param $this
+     */
+    public function setPlural($label)
+    {
+        $this->merge(
+            LabelsCollection::make($this->plural)->setForm($label)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Get all the labels as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->labels ? $this->labels->toArray() : [];
+    }
+
+    /**
+     * Merge the labels with the master collection.
+     *
+     * @param  LabelsCollection $collection
+     */
+    protected function merge(LabelsCollection $collection)
+    {
+        if (! $this->labels) {
+            $this->labels = new Collection;
+        }
+
+        $this->labels = $this->labels->merge($collection->replaced());
+    }
+}

--- a/src/Post/PostTypeLabels.php
+++ b/src/Post/PostTypeLabels.php
@@ -48,7 +48,9 @@ class PostTypeLabels
     /**
      * Set the singular labels using the given form.
      *
-     * @param $this
+     * @param $label The singular label form to use
+     *
+     * @return $this
      */
     public function setSingular($label)
     {
@@ -62,7 +64,9 @@ class PostTypeLabels
     /**
      * Set the plural labels using the given form.
      *
-     * @param $this
+     * @param $label The plural label form to use
+     *
+     * @return $this
      */
     public function setPlural($label)
     {

--- a/src/Support/LabelsCollection.php
+++ b/src/Support/LabelsCollection.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Silk\Support;
+
+use Illuminate\Support\Collection;
+
+class LabelsCollection extends Collection
+{
+    /**
+     * The label form (singular, plural, or otherwise)
+     * @var string
+     */
+    protected $form;
+
+    /**
+     * Set the form.
+     *
+     * @param string $label  The label form to use for this collection
+     */
+    public function setForm($label)
+    {
+        $this->form = $label;
+
+        return $this;
+    }
+
+    /**
+     * Get a new collection with replaced placeholders in items using the provided form.
+     *
+     * @return $this
+     */
+    public function replaced()
+    {
+        return $this->map(function ($label) {
+            return $this->replaceWithForm($label);
+        });
+    }
+
+    /**
+     * Replace all placeholders in the label with the given label form.
+     *
+     * @param  string $label The label to make replacements in
+     *
+     * @return string   The label after replacements have been made
+     */
+    protected function replaceWithForm($label)
+    {
+        return sprintf($label, $this->form);
+    }
+
+    /**
+     * Get a specific label, after replacements have been made.
+     *
+     * @param  string $key     The label key
+     * @param  string $default The default value, if no label if found for key
+     *
+     * @return string The label after replacements have been made
+     */
+    public function get($key, $default = null)
+    {
+        $label = parent::get($key, $default);
+
+        return $this->replaceWithForm($label);
+    }
+
+    /**
+     * Make replacements and return the collection as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->replaced()->all();
+    }
+}

--- a/tests/unit/Post/PostTypeBuilderTest.php
+++ b/tests/unit/Post/PostTypeBuilderTest.php
@@ -115,10 +115,17 @@ class PostTypeBuilderTest extends WP_UnitTestCase
     {
         $book = PostTypeBuilder::make('book')
             ->oneIs('Book')
-            ->manyAre('Books');
+            ->manyAre('Books')
+            ->register();
 
-        $this->assertSame('Book', $book->one);
-        $this->assertSame('Books', $book->many);
+        $labels = get_post_type_labels($book->object());
+
+
+        $this->assertSame('Book', $labels->singular_name);
+        $this->assertSame('Books', $labels->name);
+        $this->assertSame('All Books', $labels->all_items);
+        $this->assertSame('Edit Book', $labels->edit_item);
+        $this->assertSame('Add New Book', $labels->add_new_item);
     }
 
     /**

--- a/tests/unit/Post/PostTypeBuilderTest.php
+++ b/tests/unit/Post/PostTypeBuilderTest.php
@@ -131,14 +131,6 @@ class PostTypeBuilderTest extends WP_UnitTestCase
     /**
      * @test
      */
-    function it_makes_the_slug_available_as_a_read_only_property()
-    {
-        $this->assertSame('book', PostTypeBuilder::make('book')->slug);
-    }
-
-    /**
-     * @test
-     */
     function it_returns_null_for_non_existent_properties()
     {
         $this->assertNull(PostTypeBuilder::make('book')->nonExistentProperty);

--- a/tests/unit/Support/LabelsCollectionTest.php
+++ b/tests/unit/Support/LabelsCollectionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Silk\Support\LabelsCollection;
+
+class LabelsCollectionTest extends WP_UnitTestCase
+{
+    /**
+     * @test
+     */
+    function it_takes_an_array_of_labels_and_replaces_placeholders_with_the_given_form()
+    {
+        $collection = new LabelsCollection([
+            'greeting' => 'Hi %s'
+        ]);
+        $collection->setForm('there');
+
+        $this->assertSame('Hi there', $collection->get('greeting'));
+
+        $this->assertSame(['greeting' => 'Hi there'], $collection->toArray());
+        $this->assertSame(['greeting' => 'Hi there'], $collection->replaced()->all());
+    }
+
+}


### PR DESCRIPTION
This PR fixes #6 with easy handling of PostType labels.

All post types require labels at registration time.  Previously, registering a post type with Silk did not set post type labels for all labels which referenced the single or plural forms of the label.

This feature enables the most common use cases to set all custom post type labels using the provided methods:

``` php
$post_type->oneIs('Book')
    ->manyAre('Books')
    ->register();
```
