### PR TITLE
Version 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## v0.10.1 (2016-)
+
+### Fixed
+- Strict notice on PHP 5 for abstract static method
+
 ## v0.10.0 (2016-07-16)
 
 ### Added

--- a/src/Post/Action/Action.php
+++ b/src/Post/Action/Action.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Silk\Post\Action;
+
+use Silk\Post\Model;
+use Silk\Contracts\Executable;
+
+abstract class Action implements Executable
+{
+    /**
+     * The model instance
+     * @var \Silk\Post\Model
+     */
+    protected $model;
+
+    /**
+     * Action Constructor.
+     *
+     * @param Model $model The model performing the action
+     */
+    public function __construct(Model $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Execute the action.
+     *
+     * @return void
+     */
+    abstract public function execute();
+}

--- a/src/Post/Action/PostDeleter.php
+++ b/src/Post/Action/PostDeleter.php
@@ -2,8 +2,6 @@
 
 namespace Silk\Post\Action;
 
-use Silk\Database\Action;
-
 class PostDeleter extends Action
 {
     public function execute()

--- a/src/Post/Action/PostLoader.php
+++ b/src/Post/Action/PostLoader.php
@@ -2,8 +2,6 @@
 
 namespace Silk\Post\Action;
 
-use Silk\Database\Action;
-
 class PostLoader extends Action
 {
     public function execute()

--- a/src/Post/Action/PostSaver.php
+++ b/src/Post/Action/PostSaver.php
@@ -2,7 +2,6 @@
 
 namespace Silk\Post\Action;
 
-use Silk\Database\Action;
 use Silk\Exception\WP_ErrorException;
 
 class PostSaver extends Action

--- a/src/Post/Model.php
+++ b/src/Post/Model.php
@@ -160,16 +160,6 @@ abstract class Model extends BaseModel
     }
 
     /**
-     * Get the post type identifier for this model.
-     *
-     * @return string
-     */
-    public static function typeId()
-    {
-        return static::postTypeId();
-    }
-
-    /**
      * Get the post type identifier for this model
      *
      * @return string post type identifier (slug)

--- a/src/Term/Action/Action.php
+++ b/src/Term/Action/Action.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Silk\Term\Action;
+
+use Silk\Term\Model;
+use Silk\Contracts\Executable;
+
+abstract class Action implements Executable
+{
+    /**
+     * The model instance
+     * @var \Silk\Term\Model
+     */
+    protected $model;
+
+    /**
+     * Action Constructor.
+     *
+     * @param Model $model The model performing the action
+     */
+    public function __construct(Model $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Execute the action.
+     *
+     * @return void
+     */
+    abstract public function execute();
+}

--- a/src/Term/Action/TermDeleter.php
+++ b/src/Term/Action/TermDeleter.php
@@ -2,8 +2,6 @@
 
 namespace Silk\Term\Action;
 
-use Silk\Database\Action;
-
 class TermDeleter extends Action
 {
     public function execute()

--- a/src/Term/Action/TermDeleter.php
+++ b/src/Term/Action/TermDeleter.php
@@ -6,7 +6,7 @@ class TermDeleter extends Action
 {
     public function execute()
     {
-        if (wp_delete_term($this->model->id, $this->model->typeId())) {
+        if (wp_delete_term($this->model->id, $this->model->taxonomy)) {
             $this->model->setObject(new \WP_Term(new \stdClass));
         }
     }

--- a/src/Term/Action/TermLoader.php
+++ b/src/Term/Action/TermLoader.php
@@ -7,7 +7,7 @@ class TermLoader extends Action
     public function execute()
     {
         $this->model->setObject(
-            \WP_Term::get_instance($this->model->id, $this->model->typeId())
+            \WP_Term::get_instance($this->model->id, $this->model->taxonomy)
         );
     }
 }

--- a/src/Term/Action/TermLoader.php
+++ b/src/Term/Action/TermLoader.php
@@ -2,8 +2,6 @@
 
 namespace Silk\Term\Action;
 
-use Silk\Database\Action;
-
 class TermLoader extends Action
 {
     public function execute()

--- a/src/Term/Action/TermSaver.php
+++ b/src/Term/Action/TermSaver.php
@@ -8,12 +8,10 @@ class TermSaver extends Action
 {
     public function execute()
     {
-        $taxonomy = $this->model->typeId();
-
         if ($this->model->id) {
-            $ids = wp_update_term($this->model->id, $taxonomy, $this->model->object->to_array());
+            $ids = wp_update_term($this->model->id, $this->model->taxonomy, $this->model->object->to_array());
         } else {
-            $ids = wp_insert_term($this->model->name, $taxonomy, $this->model->object->to_array());
+            $ids = wp_insert_term($this->model->name, $this->model->taxonomy, $this->model->object->to_array());
         }
 
         if (is_wp_error($ids)) {

--- a/src/Term/Action/TermSaver.php
+++ b/src/Term/Action/TermSaver.php
@@ -2,7 +2,6 @@
 
 namespace Silk\Term\Action;
 
-use Silk\Database\Action;
 use Silk\Exception\WP_ErrorException;
 
 class TermSaver extends Action

--- a/src/Term/Model.php
+++ b/src/Term/Model.php
@@ -194,16 +194,6 @@ abstract class Model extends BaseModel
     }
 
     /**
-     * Get the taxonomy identifier for the model.
-     *
-     * @return string
-     */
-    public static function typeId()
-    {
-        return static::taxonomy()->id;
-    }
-
-    /**
      * Get the Taxonomy model.
      *
      * @return Taxonomy|\Silk\Taxonomy\Builder

--- a/src/Type/Model.php
+++ b/src/Type/Model.php
@@ -37,13 +37,6 @@ abstract class Model
     abstract protected function actionClasses();
 
     /**
-     * Get the model's type identifier.
-     *
-     * @return string
-     */
-    abstract public static function typeId();
-
-    /**
     * Get a new query builder for the model.
     *
     * @return \Silk\Contracts\BuildsQueries

--- a/tests/unit/Post/ModelTest.php
+++ b/tests/unit/Post/ModelTest.php
@@ -14,9 +14,6 @@ class ModelTest extends PHPUnit_Framework_TestCase
         $this->assertSame('event', ModelTestEventTrait::postTypeId());
         $this->assertSame('model_test_post_type', ModelTestPostType::postTypeId());
         $this->assertSame('dinosaur', Dinosaur::postTypeId());
-
-        $this->assertSame('event', ModelTestEvent::typeId());
-        $this->assertSame('event', ModelTestEventTrait::typeId());
     }
 
     /**


### PR DESCRIPTION
Apparently PHPUnit does not fail on strict errors.

This update removes the need for the abstract static method causing the error for PHP 5.  The recent work on the upcoming User\Model class also shows that this method was unnecessary.
